### PR TITLE
Fix repository URL in README.md for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@ pip install jpy-sync-db-lite
 
 ### From source
 ```bash
-git clone https://github.com/jimschilling/jpy-sync-db-lite.git
+git clone https://github.com/jim-schilling/jpy-sync-db-lite.git
 cd jpy-sync-db-lite
 pip install -e .
 ```
 
 ### Development setup
 ```bash
-git clone https://github.com/jimschilling/jpy-sync-db-lite.git
+git clone https://github.com/jim-schilling/jpy-sync-db-lite.git
 cd jpy-sync-db-lite
 pip install -e ".[dev]"
 ```


### PR DESCRIPTION
This pull request includes a minor update to the `README.md` file to correct the GitHub repository URL for cloning the `jpy-sync-db-lite` project.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L26-R33): Updated the repository URL from `https://github.com/jimschilling/jpy-sync-db-lite.git` to `https://github.com/jim-schilling/jpy-sync-db-lite.git` in both the "From source" and "Development setup" sections.